### PR TITLE
Combined: 3 Dependabot dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1095,9 +1095,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -2320,9 +2320,9 @@
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
         },
         "path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
         },
         "picomatch": {
             "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "inrix-hack-2022",
             "version": "1.0.0",
             "dependencies": {
-                "axios": "^1.13.5",
+                "axios": "^1.15.0",
                 "cors": "^2.8.5",
                 "dotenv": "^10.0.0",
                 "express": "^4.22.1",
@@ -216,13 +216,13 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -1124,9 +1124,12 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
@@ -1695,13 +1698,13 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "requires": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "balanced-match": {
@@ -2340,9 +2343,9 @@
             }
         },
         "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
         },
         "pstree.remy": {
             "version": "1.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,9 +1100,9 @@
             "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "engines": {
                 "node": ">=8.6"
@@ -2325,9 +2325,9 @@
             "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
         },
         "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true
         },
         "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "keywords": [],
     "author": "",
     "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",
         "express": "^4.22.1",


### PR DESCRIPTION
Combined Dependabot dependency updates (3 PRs):

- Bump axios from 1.13.5 to 1.15.0 (#25)
- Bump path-to-regexp from 0.1.12 to 0.1.13 (#24)
- Bump picomatch from 2.3.1 to 2.3.2 (#23)

This PR combines all open Dependabot updates to verify CI passes before merging.